### PR TITLE
Add PyYAML dependency checks with install guidance

### DIFF
--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -16,6 +16,10 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 
+from src.utils.dependencies import require_dependencies
+
+require_dependencies([("yaml", "pyyaml")])
+
 import yaml
 from tqdm import tqdm
 

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -24,6 +24,10 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 
+from src.utils.dependencies import require_dependencies
+
+require_dependencies([("yaml", "pyyaml")])
+
 import yaml
 
 from src.inference.pipeline import TranslationPipeline, BatchTranslator

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -15,6 +15,10 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 
+from src.utils.dependencies import require_dependencies
+
+require_dependencies([("yaml", "pyyaml")])
+
 import yaml
 import torch
 from transformers import (

--- a/src/inference/pipeline.py
+++ b/src/inference/pipeline.py
@@ -6,9 +6,13 @@
 import torch
 from typing import List, Optional, Dict, Any, Union
 from pathlib import Path
-import yaml
 from dataclasses import dataclass
 
+from src.utils.dependencies import require_dependencies
+
+require_dependencies([("yaml", "pyyaml")])
+
+import yaml
 from transformers import AutoModelForCausalLM, AutoTokenizer
 from peft import PeftModel
 

--- a/src/model/loader.py
+++ b/src/model/loader.py
@@ -6,8 +6,12 @@ EXAONE 3.5-7.8B 모델을 로드하고 LoRA/QLoRA를 적용합니다.
 import torch
 from typing import Tuple, Optional, Dict, Any
 from pathlib import Path
-import yaml
 
+from src.utils.dependencies import require_dependencies
+
+require_dependencies([("yaml", "pyyaml")])
+
+import yaml
 from transformers import (
     AutoModelForCausalLM,
     AutoTokenizer,

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility helpers for dependency management and shared helpers."""

--- a/src/utils/dependencies.py
+++ b/src/utils/dependencies.py
@@ -1,0 +1,28 @@
+"""Dependency checks and helpful install guidance."""
+
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+
+def require_dependencies(modules: Sequence[tuple[str, str]]) -> None:
+    """Ensure modules can be imported, otherwise raise helpful error.
+
+    Args:
+        modules: Sequence of (import_name, pip_name) pairs.
+    """
+    missing: list[str] = []
+    for import_name, pip_name in modules:
+        try:
+            __import__(import_name)
+        except ModuleNotFoundError:
+            missing.append(pip_name)
+
+    if missing:
+        packages = " ".join(sorted(set(missing)))
+        raise ModuleNotFoundError(
+            "Missing required dependencies. Install with:\n"
+            f"  python -m pip install {packages}\n"
+            "If you're installing from requirements.txt, run:\n"
+            "  python -m pip install -r requirements.txt\n"
+        )


### PR DESCRIPTION
### Motivation
- Prevent a confusing `ModuleNotFoundError: No module named 'yaml'` at runtime by surfacing an actionable message. 
- Make scripts and core loaders fail fast when PyYAML is not available so users know how to install the correct package. 
- Avoid users attempting to install the nonexistent `yaml` package by recommending the correct pip package. 

### Description
- Add `src/utils/dependencies.py` which provides `require_dependencies` and prints an actionable install hint such as `python -m pip install pyyaml` or `python -m pip install -r requirements.txt` when imports are missing. 
- Wire the dependency guard into `scripts/train.py`, `scripts/evaluate.py`, `scripts/inference.py`, `src/inference/pipeline.py`, and `src/model/loader.py` by calling `require_dependencies([("yaml", "pyyaml")])` before `import yaml`. 
- Add `src/utils/__init__.py` to make the `src.utils` package importable. 

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f3f4571b4832c84edda85899c576f)