### PR TITLE
Pin flash-attn wheel for CUDA12/Torch 2.8 and add runtime availability check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "accelerate>=0.24.0",
     "peft>=0.7.0",
     "bitsandbytes>=0.41.0",
+    "flash-attn @ https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.3/flash_attn-2.8.3+cu12torch2.8cxx11abiTRUE-cp311-cp311-linux_x86_64.whl",
     "sacrebleu>=2.3.0",
     "unbabel-comet>=2.2.0",
     "evaluate>=0.4.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ accelerate>=0.24.0
 # PEFT & Quantization
 peft>=0.7.0
 bitsandbytes>=0.41.0
+flash-attn @ https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.3/flash_attn-2.8.3+cu12torch2.8cxx11abiTRUE-cp311-cp311-linux_x86_64.whl
 
 # Evaluation
 sacrebleu>=2.3.0

--- a/src/model/loader.py
+++ b/src/model/loader.py
@@ -3,6 +3,7 @@
 EXAONE 3.5-7.8B 모델을 로드하고 LoRA/QLoRA를 적용합니다.
 """
 
+import importlib.util
 import torch
 from typing import Tuple, Optional, Dict, Any
 from pathlib import Path
@@ -169,7 +170,13 @@ class ModelLoader:
         # Attention 구현 선택
         attn_implementation = None
         if model_config.get('use_flash_attention', True):
-            attn_implementation = "flash_attention_2"
+            if importlib.util.find_spec("flash_attn") is not None:
+                attn_implementation = "flash_attention_2"
+            else:
+                print(
+                    "FlashAttention2 requested but flash_attn is not installed. "
+                    "Falling back to default attention implementation."
+                )
 
         # 모델 로드
         model = AutoModelForCausalLM.from_pretrained(


### PR DESCRIPTION
### Motivation
- Ensure `flash-attn` is declared as a project dependency via a specific wheel URL for CUDA12 / Torch 2.8 / CPython 3.11 Linux to match the referenced install command.
- Avoid attempting runtime `pip` installs from the model loader in controlled or offline environments.
- Allow the model loader to enable `flash_attention_2` only when the `flash_attn` package is actually available to prevent runtime errors.

### Description
- Replace the previous `flash-attn` requirement by pinning the wheel URL in `requirements.txt` and `pyproject.toml` to the CUDA12/Torch2.8 CPython3.11 Linux wheel.  
- Update `src/model/loader.py` to use `importlib.util.find_spec("flash_attn")` and set `attn_implementation="flash_attention_2"` only when the package is found, otherwise print a clear fallback message.  
- Keep existing quantization and LoRA preparation logic unchanged.

### Testing
- No automated tests were executed for this change and CI was not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f47851cb0832cb2b54696d110ec8f)