### PR TITLE
Fix training script QLoRA initialization issue

### DIFF
--- a/configs/qlora_config.yaml
+++ b/configs/qlora_config.yaml
@@ -33,5 +33,5 @@ lora:
 
 # Model loading settings
 model:
-  use_flash_attention: true
+  use_flash_attention: false  # Set to false if flash_attn is not installed
   device_map: "auto"

--- a/src/model/loader.py
+++ b/src/model/loader.py
@@ -75,7 +75,7 @@ class ModelLoader:
                 'use_rslora': True
             },
             'model': {
-                'use_flash_attention': True,
+                'use_flash_attention': False,
                 'device_map': 'auto'
             }
         }
@@ -168,8 +168,16 @@ class ModelLoader:
 
         # Attention 구현 선택
         attn_implementation = None
-        if model_config.get('use_flash_attention', True):
-            attn_implementation = "flash_attention_2"
+        if model_config.get('use_flash_attention', False):
+            try:
+                import flash_attn
+                attn_implementation = "flash_attention_2"
+                print("Using FlashAttention2")
+            except ImportError:
+                print("FlashAttention2 not available, using default attention implementation")
+                attn_implementation = "eager"
+        else:
+            attn_implementation = "eager"
 
         # 모델 로드
         model = AutoModelForCausalLM.from_pretrained(


### PR DESCRIPTION
- Disable use_flash_attention by default in qlora_config.yaml
- Add automatic fallback to eager attention when flash_attn is not installed
- Update default config in ModelLoader to use eager attention
- Add informative messages when FlashAttention2 is/isn't available

This allows QLoRA training to work without requiring flash_attn package installation, which can be complex and environment-dependent.